### PR TITLE
Added Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Features
 - References GPIO pins by physical pin number
 - Includes functions for detecting presence of and reading status of on-board
   key/button (not all boards have one)
-- Swig is used to generate Python bindings
+- Swig is used to generate Python bindings (maybe other languages in the future)
  
 To build the C library, simply type 'make' in the terminal. To build the sample
 app, type 'make -f make_demo'. This will build the 'demo' executable to show

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Features
   key/button (not all boards have one)
 - Swig is used to generate Python bindings
  
-To build the library, simply type 'make' in the terminal. To build the sample
+To build the C library, simply type 'make' in the terminal. To build the sample
 app, type 'make -f make_demo'. This will build the 'demo' executable to show
 that the library is working.
+
+To build Python bindings `cd ArmbianIO/python` then `./swig.sh`
 
 Copyright (c) 2017 by Larry Bank
 Project started 11/13/2017

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*** ArmbianIO ***
+### ArmbianIO
 
 ArmbianIO is a C library for accessing I2C, SPI and GPIO ports in a consistent
 way across all of the SBCs that Armbian supports. Since Armbian supports SBCs
@@ -26,6 +26,7 @@ Features
 - References GPIO pins by physical pin number
 - Includes functions for detecting presence of and reading status of on-board
   key/button (not all boards have one)
+- Swig is used to generate Python bindings
  
 To build the library, simply type 'make' in the terminal. To build the sample
 app, type 'make -f make_demo'. This will build the 'demo' executable to show

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### ArmbianIO
+## ArmbianIO
 
 ArmbianIO is a C library for accessing I2C, SPI and GPIO ports in a consistent
 way across all of the SBCs that Armbian supports. Since Armbian supports SBCs
@@ -32,7 +32,9 @@ To build the C library, simply type 'make' in the terminal. To build the sample
 app, type 'make -f make_demo'. This will build the 'demo' executable to show
 that the library is working.
 
-To build Python bindings `cd ArmbianIO/python` then `./swig.sh`
+To build Python bindings `cd ArmbianIO/python` then `./swig.sh`. You can run as
+many times as you like since the script cleans up and regerates the wrapper
+from the C headers.
 
 Copyright (c) 2017 by Larry Bank
 Project started 11/13/2017

--- a/python/armbianio.i
+++ b/python/armbianio.i
@@ -1,0 +1,12 @@
+ /*
+ Swig interface file
+ */
+
+ %module ArmbianIO
+ %{
+ /* Includes the header in the wrapper code */
+ #include "../armbianio.h"
+ %}
+
+ /* Parse the header file to generate wrappers */
+ %include "../armbianio.h"

--- a/python/armbianio.i
+++ b/python/armbianio.i
@@ -2,7 +2,7 @@
  Swig interface file
  */
 
- %module ArmbianIO
+ %module armbianio
  %{
  /* Includes the header in the wrapper code */
  #include "../armbianio.h"

--- a/python/ledtest.py
+++ b/python/ledtest.py
@@ -1,0 +1,12 @@
+import time
+from armbianio.armbianio import *
+
+rc = AIOInit()
+if rc == 1:
+    AIOAddGPIO(12, GPIO_OUT)
+    AIOWriteGPIO(12, 0)
+    time.sleep(3)
+    AIOWriteGPIO(12, 1)
+    AIOShutdown()
+else:
+    print "AIOInit error"

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='armbianio',
+      version='0.1',
+      description='ArmbianIO Python wrapper',
+      url='https://github.com/bitbank2/ArmbianIO',
+      author='Steven P. Goldsmith',
+      author_email='sgjava@gmail.com',
+      license='GNU GENERAL PUBLIC LICENSE',
+      packages=['armbianio'],
+      zip_safe=False)

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -13,11 +13,20 @@ if [ $(dpkg-query -W -f='${Status}' python-dev 2>/dev/null | grep -c "ok install
 then
 	sudo apt-get -y install python-dev;
 fi
-# Install python-pip
+
+# Install pip
 if [ $(dpkg-query -W -f='${Status}' python-pip 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
 	sudo apt-get -y install python-pip;
 fi
+# Check pip	
+if python -c "import pip" &> /dev/null; then
+    echo 'pip OK'
+else
+	sudo -H pip install --upgrade pip;
+ 	sudo apt-get -y purge python-pip;
+fi
+
 # Install swig
 if [ $(dpkg-query -W -f='${Status}' swig 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -3,7 +3,7 @@
 # Create Python bindings
 
 # Get python includes
-includes=$(command-name-here)
+includes=$(python-config --includes)
 
 swig -python armbianio.i
 gcc -c -fPIC ../armbianio.c ArmbianIO_wrap.c $includes

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Create Python bindings
+
+swig -python armbianio.i
+gcc -c -fPIC ../armbianio.c ArmbianIO_wrap.c -I/usr/include/python2.7
+ld -shared ../armbianio.o ArmbianIO_wrap.o -o _ArmbianIO.so

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 
-# Create Python bindings
+# Create Python bindings as armbianio module
 
 # Get python includes
 includes=$(python-config --includes)
 
+# Generate module
 swig -python armbianio.i
-gcc -c -fPIC ../armbianio.c ArmbianIO_wrap.c $includes
-ld -shared ../armbianio.o ArmbianIO_wrap.o -o _ArmbianIO.so
+# Compile wrapper
+gcc -c -fPIC ../armbianio.c armbianio_wrap.c $includes
+# Link objects
+ld -shared armbianio.o armbianio_wrap.o -o _armbianio.so

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -19,3 +19,6 @@ ld -shared armbianio.o armbianio_wrap.o -o _armbianio.so
 
 # Deploy shared library
 sudo cp _armbianio.so /usr/local/lib/.
+
+# Install Python package
+sudo -H pip install -e .

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -2,12 +2,19 @@
 
 # Create Python bindings as armbianio module
 
+# Run in the python dir of the ArmbianIO project
+
+# Clean up
+rm -f *.c *.o *.so armbianio/armbianio.* /usr/local/lib/_armbianio.so
+
 # Get python includes
 includes=$(python-config --includes)
-
 # Generate module in package
 swig -python -outdir armbianio armbianio.i
 # Compile wrapper
 gcc -c -fPIC ../armbianio.c armbianio_wrap.c $includes
 # Link objects
 ld -shared armbianio.o armbianio_wrap.o -o _armbianio.so
+
+# Deploy shared library
+cp _armbianio.so /usr/local/lib/.

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -5,7 +5,8 @@
 # Run in the python dir of the ArmbianIO project
 
 # Clean up
-rm -f *.c *.o *.so armbianio/armbianio.* /usr/local/lib/_armbianio.so
+rm -f *.c *.o *.so armbianio/armbianio.*
+sudo rm -f /usr/local/lib/_armbianio.so
 
 # Get python includes
 includes=$(python-config --includes)
@@ -17,4 +18,4 @@ gcc -c -fPIC ../armbianio.c armbianio_wrap.c $includes
 ld -shared armbianio.o armbianio_wrap.o -o _armbianio.so
 
 # Deploy shared library
-cp _armbianio.so /usr/local/lib/_armbianio.so
+sudo cp _armbianio.so /usr/local/lib/.

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -11,11 +11,6 @@ sudo rm -f /usr/local/lib/_armbianio.so
 # Get python includes
 includes=$(python-config --includes)
 
-# Install swig
-if [ $(dpkg-query -W -f='${Status}' swig 2>/dev/null | grep -c "ok installed") -eq 0 ];
-then
-	sudo apt-get -y install swig;
-fi
 # Install python-dev
 if [ $(dpkg-query -W -f='${Status}' python-dev 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
@@ -25,6 +20,11 @@ fi
 if [ $(dpkg-query -W -f='${Status}' python-pip 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
 	sudo apt-get -y install python-pip;
+fi
+# Install swig
+if [ $(dpkg-query -W -f='${Status}' swig 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+	sudo apt-get -y install swig;
 fi
 
 # Generate module in package

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -8,9 +8,6 @@
 rm -f *.c *.o *.so armbianio/armbianio.*
 sudo rm -f /usr/local/lib/_armbianio.so
 
-# Get python includes
-includes=$(python-config --includes)
-
 # Install python-dev
 if [ $(dpkg-query -W -f='${Status}' python-dev 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
@@ -26,6 +23,9 @@ if [ $(dpkg-query -W -f='${Status}' swig 2>/dev/null | grep -c "ok installed") -
 then
 	sudo apt-get -y install swig;
 fi
+
+# Get python includes
+includes=$(python-config --includes)
 
 # Generate module in package
 swig -python -outdir armbianio armbianio.i

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -17,7 +17,7 @@ fi
 # Install pip
 if ! python -c "import pip" &> /dev/null; then
 	sudo apt-get -y install python-pip;
-	sudo -H pip install --upgrade pip;
+	sudo -H pip install --upgrade pip setuptools;
  	sudo apt-get -y purge python-pip;
 fi
 

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -18,7 +18,7 @@ fi
 if ! python -c "import pip" &> /dev/null; then
 	sudo apt-get -y install python-pip;
 	sudo -H pip install --upgrade pip;
- 	sudo apt-get -y purge python-pip;fi
+ 	sudo apt-get -y purge python-pip;
 fi
 
 # Install swig

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -5,8 +5,8 @@
 # Get python includes
 includes=$(python-config --includes)
 
-# Generate module
-swig -python armbianio.i
+# Generate module in package
+swig -python -outdir armbianio armbianio.i
 # Compile wrapper
 gcc -c -fPIC ../armbianio.c armbianio_wrap.c $includes
 # Link objects

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -2,6 +2,9 @@
 
 # Create Python bindings
 
+# Get python includes
+includes=$(command-name-here)
+
 swig -python armbianio.i
-gcc -c -fPIC ../armbianio.c ArmbianIO_wrap.c -I/usr/include/python2.7
+gcc -c -fPIC ../armbianio.c ArmbianIO_wrap.c $includes
 ld -shared ../armbianio.o ArmbianIO_wrap.o -o _ArmbianIO.so

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -15,16 +15,10 @@ then
 fi
 
 # Install pip
-if [ $(dpkg-query -W -f='${Status}' python-pip 2>/dev/null | grep -c "ok installed") -eq 0 ];
-then
+if ! python -c "import pip" &> /dev/null; then
 	sudo apt-get -y install python-pip;
-fi
-# Check pip	
-if python -c "import pip" &> /dev/null; then
-    echo 'pip OK'
-else
 	sudo -H pip install --upgrade pip;
- 	sudo apt-get -y purge python-pip;
+ 	sudo apt-get -y purge python-pip;fi
 fi
 
 # Install swig

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -11,11 +11,22 @@ sudo rm -f /usr/local/lib/_armbianio.so
 # Get python includes
 includes=$(python-config --includes)
 
-# Install swig if needed
+# Install swig
 if [ $(dpkg-query -W -f='${Status}' swig 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
-  apt-get -y install swig;
+	sudo apt-get -y install swig;
 fi
+# Install python-dev
+if [ $(dpkg-query -W -f='${Status}' python-dev 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+	sudo apt-get -y install python-dev;
+fi
+# Install python-pip
+if [ $(dpkg-query -W -f='${Status}' python-pip 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+	sudo apt-get -y install python-pip;
+fi
+
 # Generate module in package
 swig -python -outdir armbianio armbianio.i
 # Compile wrapper

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -10,6 +10,12 @@ sudo rm -f /usr/local/lib/_armbianio.so
 
 # Get python includes
 includes=$(python-config --includes)
+
+# Install swig if needed
+if [ $(dpkg-query -W -f='${Status}' swig 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+  apt-get -y install swig;
+fi
 # Generate module in package
 swig -python -outdir armbianio armbianio.i
 # Compile wrapper

--- a/python/swig.sh
+++ b/python/swig.sh
@@ -17,4 +17,4 @@ gcc -c -fPIC ../armbianio.c armbianio_wrap.c $includes
 ld -shared armbianio.o armbianio_wrap.o -o _armbianio.so
 
 # Deploy shared library
-cp _armbianio.so /usr/local/lib/.
+cp _armbianio.so /usr/local/lib/_armbianio.so


### PR DESCRIPTION
I kept everything in the python dir so as not to pollute the C project. It's totally independent as the swig.sh script will generate a shared library (so) and doesn't require you to make the C project first. I tested this with a clean install of Armbian on the NanoPi Duo, so it would be nice to test on other SBCs. I'll try to port the C demo to Python. I included a demo that blinks one LED on pin 12 of the Duo. The armbianio package will install locally using pip, so it's in the global path for Python program.