### PR TITLE
Add NanoPi Neo Air support

### DIFF
--- a/armbianio.c
+++ b/armbianio.c
@@ -120,8 +120,8 @@ static int iTinkerPins[] = {-1,-1,-1,252,-1,253,-1,17,161,-1,
 			-1,168,239,238,-1,185,223,224,187,-1,
 			188};
 
-static int *iPinLists[] = {iBPIZPins, iRPIPins, iOPIZPPins, iOPIZP2ins, iOPIZPins, iOPI1Pins, iOPI1Pins, iNPDPins, iNP2Pins, iNPK2Pins, iNPNPins, iTinkerPins};
-static const char *szBoardNames[] = {"Banana Pi M2 Zero\n","Raspberry Pi","Orange Pi Zero Plus\n","Orange Pi Zero Plus 2\n","Orange Pi Zero\n","Orange Pi Lite\n","Orange Pi One\n","NanoPi Duo\n", "NanoPi 2\n", "Nanopi K2\n", "NanoPi Neo\n","Tinkerboard\n",NULL};
+static int *iPinLists[] = {iBPIZPins, iRPIPins, iOPIZPPins, iOPIZP2ins, iOPIZPins, iOPI1Pins, iOPI1Pins, iNPDPins, iNP2Pins, iNPK2Pins, iNPNPins, iNPNPins, iTinkerPins};
+static const char *szBoardNames[] = {"Banana Pi M2 Zero\n","Raspberry Pi","Orange Pi Zero Plus\n","Orange Pi Zero Plus 2\n","Orange Pi Zero\n","Orange Pi Lite\n","Orange Pi One\n","NanoPi Duo\n", "NanoPi 2\n", "Nanopi K2\n", "NanoPi Neo\n", "NanoPi Air\n", "Tinkerboard\n",NULL};
 static int iBoardType;
 static int iPinCount[] = {40,40,29,29,29,43,43,32,40,40,40,40}; // number of pins in the header
 


### PR DESCRIPTION
This commit adds support for the Nano Pi NEO Air. Pins should be identical to the NanoPi Neo (non-air) version.

Even though officially the board is called NanoPi NEO Air, the identifier was used from the `/run/machine.id` file in Armbian.